### PR TITLE
Planning events are never shown on index page.

### DIFF
--- a/meetup/models.py
+++ b/meetup/models.py
@@ -73,8 +73,10 @@ class Talk(StatusModel):
 class EventQuerySet(models.query.QuerySet):
     def upcoming(self):
         try:
-            return self.filter(status=Event.STATUS.active).latest()
-        except Event.DoesNotExist:
+            return self.filter(
+                status__in=[Event.STATUS.active, Event.STATUS.planning])\
+                .order_by('status', '-id')[0]
+        except IndexError:
             return None
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -31,6 +31,12 @@ class IndexSystem(TestCase):
         response = self.client.get(reverse('index'))
         self.assertQuerysetEqual(response.context['events'], [repr(arc)])
 
+    def test_planning_event(self):
+        pln = Event.objects.create(number=3, name='Planning', status=Event.STATUS.planning)
+        Event.objects.create(number=4, name='Archived', status=Event.STATUS.archived)
+        response = self.client.get(reverse('index'))
+        self.assertEqual(response.context['main_event'], pln)
+
 
 class EventList(TestCase):
     """Integration tests for events list page"""


### PR DESCRIPTION
Currently, on index page `main_event` has always status 'active'. So planning event and corresponding subscription form are never shown on index page.

Check it out.
models.py:

```
    class EventQuerySet(models.query.QuerySet):
        def upcoming(self):
            try:
                return self.filter(status=Event.STATUS.active).latest()
            except Event.DoesNotExist:
                return None
```

views.py:

```
    context.update({
        'main_event': Event.objects.upcoming(),
    })
```

index.html:

```
    {% if main_event %}
    ...
                {% if main_event.status == 'planning' %}
                    {% include 'blocks/message.html' with event=main_event %}
                    {% include 'blocks/subscription.html' %}
    ...
                {% endif %}
    ...
    {% endif %}
```
