### PR TITLE
Fix square images of speakers

### DIFF
--- a/assets/css/content/sections.css
+++ b/assets/css/content/sections.css
@@ -357,6 +357,7 @@ section.section-speakers {
                 img {
                     width: 150px;
                     height: 150px;
+                    object-fit: cover;
                 }
             }
             .name {
@@ -426,6 +427,7 @@ section.section-archive {
                         img {
                             width: 70px;
                             height: 70px;
+                            object-fit: cover;
                         }
                     }
                     .topic {
@@ -584,6 +586,7 @@ section.section-talk {
             img {
                 width: 150px;
                 height: 150px;
+                object-fit: cover;
             }
         }
         &__name {


### PR DESCRIPTION
Here I added `object-fit: cover`, so that images fit square area. Extra parts of image will be cut off.

Before:
![Screenshot_2023-11-28_12-13-20](https://github.com/moscowpython/moscowpython/assets/11032969/29c601c1-e8fd-412d-97a5-c1c0d8263034)

After:
![Screenshot_2023-11-28_12-13-46](https://github.com/moscowpython/moscowpython/assets/11032969/99984444-66d1-4342-bc2a-71f79c05d37c)
