### PR TITLE
Add line-height for images for displaying alt message

### DIFF
--- a/assets/css/content/sections.css
+++ b/assets/css/content/sections.css
@@ -358,6 +358,7 @@ section.section-speakers {
                     width: 150px;
                     height: 150px;
                     object-fit: cover;
+                    line-height: normal;
                 }
             }
             .name {
@@ -428,6 +429,7 @@ section.section-archive {
                             width: 70px;
                             height: 70px;
                             object-fit: cover;
+                            line-height: normal;
                         }
                     }
                     .topic {
@@ -587,6 +589,7 @@ section.section-talk {
                 width: 150px;
                 height: 150px;
                 object-fit: cover;
+                line-height: normal;
             }
         }
         &__name {


### PR DESCRIPTION
a small adjustment for the line-height for images for the case when the image is missing.
Before: the line-height is too big
![Screenshot 2023-12-09 at 18 39 29](https://github.com/moscowpython/moscowpython/assets/3262288/4b9236dd-59d4-4e58-9010-c8c564351240)
After:
![Screenshot 2023-12-09 at 18 39 37](https://github.com/moscowpython/moscowpython/assets/3262288/e0c8fde5-e64d-4813-b42b-03d4ccfab76c)
